### PR TITLE
use correct port to access Admin API

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -6,9 +6,10 @@ enduro_admin_app = angular.module('enduro_admin', ['ngRoute', 'ngCookies', 'ngFi
 enduro_admin_app
 	.constant('url_config', {
 		get_base_url: function () {
-			return (window.location.href.indexOf('localhost') + 1)
-				?	'http://localhost:5000/admin_api/'
-				:	'/admin_api/'
+			if (!window.location.origin) {
+				window.location.origin = window.location.protocol + '//' + window.location.hostname + (window.location.port ? (':' + window.location.port) : '')
+			}
+			return window.location.origin + '/admin_api/'
 		},
 		get_api_url: function (api_endpoint) {
 			return this.get_base_url() + api_endpoint

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -6,10 +6,13 @@ enduro_admin_app = angular.module('enduro_admin', ['ngRoute', 'ngCookies', 'ngFi
 enduro_admin_app
 	.constant('url_config', {
 		get_base_url: function () {
-			if (!window.location.origin) {
-				window.location.origin = window.location.protocol + '//' + window.location.hostname + (window.location.port ? (':' + window.location.port) : '')
-			}
-			return window.location.origin + '/admin_api/'
+			
+			// checks for a special case when the admin runs from port 3000
+			// when developing the enduro_admin, all the api calls are redirected to port 5000
+			// otherwise will just use the regular /admin_api/ base
+			return (window.location.href.indexOf('localhost:3000') + 1)
+				? 'http://localhost:5000/admin_api/'
+				: '/admin_api/'
 		},
 		get_api_url: function (api_endpoint) {
 			return this.get_base_url() + api_endpoint


### PR DESCRIPTION
When I ran Enduro on a different Port then 5000 I could not access the Admin API. I used port 8080.
So I rewrote the get_base_url function. Since "npm i" fails on my machine I could not test the code.
But maybe its a base to start from. window.location.origin Polyfill could be placed somewhere else.

Best regards

this is the npm error I get: Failed at the contextify@0.1.15 install script 'node-gyp rebuild'.