### PR TITLE
Added option to configure min and max values for slider component

### DIFF
--- a/_generated/controls/slider_control/index.html
+++ b/_generated/controls/slider_control/index.html
@@ -1,6 +1,6 @@
 <div class="form-control col-md-12">
 	<label class="range-input">
 		<span>{{formated_key}}<i ng-if="terminated_context.info" ngtooltipster class="fa fa-info-circle tooltip control-tooltip" title="{{terminated_context.info}}"></i></span>
-		<input  ng-model="context[terminatedkey]" ng-bind="current_culture" type="range" min="0" max="100">
+		<input ng-model="context[terminatedkey]" ng-bind="current_culture" type="range" min="{{terminated_context.min || 0}}" max="{{terminated_context.max || 100}}">
 	</label>
 </div>

--- a/pages/controls/slider_control.hbs
+++ b/pages/controls/slider_control.hbs
@@ -1,6 +1,6 @@
 <div class="form-control col-md-12">
 	<label class="range-input">
 		<span>\{{formated_key}}<i ng-if="terminated_context.info" ngtooltipster class="fa fa-info-circle tooltip control-tooltip" title="\{{terminated_context.info}}"></i></span>
-		<input  ng-model="context[terminatedkey]" ng-bind="current_culture" type="range" min="0" max="100">
+		<input ng-model="context[terminatedkey]" ng-bind="current_culture" type="range" min="\{{terminated_context.min || 0}}" max="\{{terminated_context.max || 100}}">
 	</label>
 </div>


### PR DESCRIPTION
Changed option to pass in optional min and max values for the slider component via the context file.

`
{
	test:'3',
	$test_type: 'slider',
	$test_min: '0',
	$test_max: '5'
}
`